### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main", "master"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Lint, Test, and Type Check


### PR DESCRIPTION
Potential fix for [https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/1](https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access unless overridden.  
For this workflow, the best minimal non-breaking fix is:

- `permissions:`
  - `contents: read`

Place this block at workflow root level (after `on:` block and before `jobs:` is a clear location). No imports, methods, or dependencies are needed; this is purely YAML configuration. This preserves current functionality (checkout/read operations continue to work) while preventing accidental broad token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline security configuration to enforce stricter access controls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajputdivyanshu81/QuickDraw/pull/33)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->