### PR TITLE
Potential fix for code scanning alert no. 4: Use of externally-controlled format string

### DIFF
--- a/apps/excelidraw-frontend/components/VoiceChat.tsx
+++ b/apps/excelidraw-frontend/components/VoiceChat.tsx
@@ -272,7 +272,7 @@ export function VoiceChat({ roomId, socket, userId, userName }: VoiceChatProps) 
 
         // Handle remote stream
         pc.ontrack = (event) => {
-            console.log(`Received remote track from ${remoteName}`, event.streams);
+            console.log("Received remote track from %s", remoteName, event.streams);
             // Fallback for browsers that don't provide streams[0]
             const stream = event.streams[0] || new MediaStream([event.track]);
             peer.stream = stream;


### PR DESCRIPTION
Potential fix for [https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/4](https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/4)

General fix: never let untrusted data control the format string argument in logging/formatting APIs. Keep the first argument constant and pass untrusted values as separate `%s`/argument parameters.

Best targeted fix in `apps/excelidraw-frontend/components/VoiceChat.tsx` is to replace the interpolated template literal at the remote-track log site with a constant format string and pass `remoteName` as a separate argument:
- From: ``console.log(`Received remote track from ${remoteName}`, event.streams);``
- To: `console.log("Received remote track from %s", remoteName, event.streams);`

No import or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor improvement to internal logging in voice communication features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajputdivyanshu81/QuickDraw/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->