### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -2,6 +2,9 @@
 
 name: Manual workflow
 
+permissions:
+  contents: read
+
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/2](https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/manual.yml`, just below `name` (or before `jobs`). Since the workflow only runs `echo` and does not need repository/API writes, set least privilege to read-only for repository contents:

- `permissions:`
  - `contents: read`

This documents intent and prevents privilege drift if repo/org defaults change later. No imports, methods, or extra definitions are needed; just YAML configuration in this workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow security permissions configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajputdivyanshu81/QuickDraw/pull/40)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->