### PR TITLE
Potential fix for code scanning alert no. 6: Use of externally-controlled format string

### DIFF
--- a/apps/excelidraw-frontend/components/VoiceChat.tsx
+++ b/apps/excelidraw-frontend/components/VoiceChat.tsx
@@ -286,7 +286,7 @@ export function VoiceChat({ roomId, socket, userId, userName }: VoiceChatProps) 
         };
 
         pc.onconnectionstatechange = () => {
-            console.log(`Connection State with ${remoteName}:`, pc.connectionState);
+            console.log("Connection State with %s:", remoteName, pc.connectionState);
         };
 
         pc.onicecandidateerror = (event) => {


### PR DESCRIPTION
Potential fix for [https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/6](https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/6)

Use a constant format string for logging and pass untrusted values (`remoteName`) as `%s` arguments, instead of embedding them into template literals used as the first argument.

Best minimal fix (no behavior change beyond safer formatting):
- In `apps/excelidraw-frontend/components/VoiceChat.tsx`, update the log at the `pc.onconnectionstatechange` handler (line 289 region).
- Replace:
  - ``console.log(`Connection State with ${remoteName}:`, pc.connectionState);``
- With:
  - `console.log("Connection State with %s:", remoteName, pc.connectionState);`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Minor internal logging format update with no impact to user-facing functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajputdivyanshu81/QuickDraw/pull/41)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->