### PR TITLE
Potential fix for code scanning alert no. 7: Use of externally-controlled format string

### DIFF
--- a/apps/excelidraw-frontend/components/VoiceChat.tsx
+++ b/apps/excelidraw-frontend/components/VoiceChat.tsx
@@ -294,7 +294,7 @@ export function VoiceChat({ roomId, socket, userId, userName }: VoiceChatProps) 
             if (event.errorCode === 701) {
                 console.warn(`ICE Warning (701) with ${remoteName}: STUN binding timeout (likely a blocked path, harmless if other candidates work).`);
             } else {
-                console.error(`ICE Candidate Error with ${remoteName}:`, event.errorCode, event.errorText);
+                console.error("ICE Candidate Error with %s:", remoteName, event.errorCode, event.errorText);
             }
         };
 


### PR DESCRIPTION
Potential fix for [https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/7](https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/7)

Use a constant literal format string in the logging call, and pass `remoteName` as a separate `%s` argument instead of embedding it into the first argument.

Best fix in `apps/excelidraw-frontend/components/VoiceChat.tsx`:
- Change line 297 from template-literal first argument to:
  - `console.error("ICE Candidate Error with %s:", remoteName, event.errorCode, event.errorText);`

This preserves behavior (same logged information) while preventing untrusted input from controlling the format string. No new imports, helper methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice communication error handling and logging for better troubleshooting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajputdivyanshu81/QuickDraw/pull/43)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->