### PR TITLE
Potential fix for code scanning alert no. 5: Use of externally-controlled format string

### DIFF
--- a/apps/excelidraw-frontend/components/VoiceChat.tsx
+++ b/apps/excelidraw-frontend/components/VoiceChat.tsx
@@ -280,7 +280,7 @@ export function VoiceChat({ roomId, socket, userId, userName }: VoiceChatProps) 
         };
 
         pc.oniceconnectionstatechange = () => {
-            console.log(`ICE State with ${remoteName}:`, pc.iceConnectionState);
+            console.log("ICE State with %s: %s", remoteName, pc.iceConnectionState);
             peer.status = pc.iceConnectionState;
             setPeers({ ...peersRef.current });
         };


### PR DESCRIPTION
Potential fix for [https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/5](https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/5)

Use a constant format string as the first argument to `console.log`, and pass untrusted values as separate substitution arguments.  
Best fix (minimal behavior change): replace
- `console.log(\`ICE State with ${remoteName}:\`, pc.iceConnectionState);`
with
- `console.log("ICE State with %s: %s", remoteName, pc.iceConnectionState);`

This preserves the same log information while preventing attacker-controlled format directives from becoming the format string.  
Edit only `apps/excelidraw-frontend/components/VoiceChat.tsx` in the `pc.oniceconnectionstatechange` block around line 283. No imports or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging format for voice connection diagnostics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajputdivyanshu81/QuickDraw/pull/44)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->