### PR TITLE
Potential fix for code scanning alert no. 5: Use of externally-controlled format string

### DIFF
--- a/apps/excelidraw-frontend/components/VoiceChat.tsx
+++ b/apps/excelidraw-frontend/components/VoiceChat.tsx
@@ -280,7 +280,7 @@ export function VoiceChat({ roomId, socket, userId, userName }: VoiceChatProps) 
         };
 
         pc.oniceconnectionstatechange = () => {
-            console.log(`ICE State with ${remoteName}:`, pc.iceConnectionState);
+            console.log("ICE State with %s:", remoteName, pc.iceConnectionState);
             peer.status = pc.iceConnectionState;
             setPeers({ ...peersRef.current });
         };


### PR DESCRIPTION
Potential fix for [https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/5](https://github.com/rajputdivyanshu81/QuickDraw/security/code-scanning/5)

Use a constant format string for `console.log` and pass untrusted values as separate arguments (or `%s` placeholders), rather than embedding untrusted data into the first argument.

Best minimal fix in `apps/excelidraw-frontend/components/VoiceChat.tsx`:
- Update the line inside `pc.oniceconnectionstatechange` where `remoteName` is interpolated into a template literal.
- Replace:
  - ``console.log(`ICE State with ${remoteName}:`, pc.iceConnectionState);``
- With:
  - `console.log("ICE State with %s:", remoteName, pc.iceConnectionState);`

This preserves existing functionality and log content while removing externally-controlled format-string construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal code quality improvement to logging formatting in voice chat functionality with no user-facing impact.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajputdivyanshu81/QuickDraw/pull/47)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->